### PR TITLE
Performance update - 3D noise is now about 2x faster than before

### DIFF
--- a/demo/3d.html
+++ b/demo/3d.html
@@ -31,9 +31,8 @@
 
   <body>
 
-      <canvas></canvas>
-      <a href="" id="drawBtn">Draw another frame</a>
-   
+    <canvas></canvas>
+    <a href="" id="drawBtn">Draw another frame</a>
 
     <script src="../src/libs/gl-matrix-min.js"></script>
     <script src="../src/noise3D.js"></script>

--- a/src/noise3D.js
+++ b/src/noise3D.js
@@ -25,9 +25,8 @@ var SimplexNoise = (function () {
         x = vec4.create(),
         y = vec4.create(),
         h = vec4.create(),
-        b0 = vec4.create(),
-        b1 = vec4.create(),
-        s0 = vec4.create(),
+        //b0 = vec4.create(),
+        //b1 = vec4.create(),
         s1 = vec4.create(),
         s0 = vec4.create(),
         sh = vec4.create(),
@@ -177,17 +176,25 @@ var SimplexNoise = (function () {
         //        + i.y + vec4(0.0, i1.y, i2.y, 1.0 ))
         //        + i.x + vec4(0.0, i1.x, i2.x, 1.0 ));
         var sum = i[2] + i[1] + i[0];
-        p[0] = sum + 0.0;
-        p[1] = sum + i1[2] + i1[1] + i1[0];
-        p[2] = sum + i2[2] + i2[1] + i2[0];
-        p[3] = sum + 3.0;
+        // Passing this straight to the perm array lookup seems to be faster. Part of performance update #2
+        //p[0] = sum;
+        //p[1] = sum + i1[2] + i1[1] + i1[0];
+        //p[2] = sum + i2[2] + i2[1] + i2[0];
+        //p[3] = sum + 3.0;
 
-        p = permute_vec4( permute_vec4( permute_vec4( p ) ) );
-        /*p[0] = perm[p[0]];
-        p[1] = perm[p[1]];
-        p[2] = perm[p[2]];
-        p[3] = perm[p[3]];*/
-        // TODO: Use perm array? Still unsure how to implement it properly to get the same noise as the GLSL version.
+        //p = permute_vec4( permute_vec4( permute_vec4( p ) ) );
+
+        // Performance update #1
+        //p[0] = perm[perm[perm[p[0]]]];
+        //p[1] = perm[perm[perm[p[1]]]];
+        //p[2] = perm[perm[perm[p[2]]]];
+        //p[3] = perm[perm[perm[p[3]]]];
+
+        // Performance update #2
+        p[0] = perm[perm[perm[sum]]];
+        p[1] = perm[perm[perm[sum + i1[2] + i1[1] + i1[0]]]];
+        p[2] = perm[perm[perm[sum + i2[2] + i2[1] + i2[0]]]];
+        p[3] = perm[perm[perm[sum + 3.0]]];
 
         // Gradients: 7x7 points over a square, mapped onto an octahedron.
         // The ring size 17*17 = 289 is close to a multiple of 49 (49*6 = 294)
@@ -243,31 +250,33 @@ var SimplexNoise = (function () {
 
         // GLSL code:
         // vec4 b0 = vec4( x.xy, y.xy );
-        b0[0] = x[0];
-        b0[1] = x[1];
-        b0[2] = y[0];
-        b0[3] = y[1];
+        // Commented out, not needed, since we can simply use the x and y vectors below.
+        //b0[0] = x[0];
+        //b0[1] = x[1];
+        //b0[2] = y[0];
+        //b0[3] = y[1];
 
         // GLSL code:
         // vec4 b1 = vec4( x.zw, y.zw );
-        b1[0] = x[2];
-        b1[1] = x[3];
-        b1[2] = y[2];
-        b1[3] = y[3];
+        // Commented out, not needed, since we can simply use the x and y vectors below.
+        //b1[0] = x[2];
+        //b1[1] = x[3];
+        //b1[2] = y[2];
+        //b1[3] = y[3];
 
         // GLSL code:
         // vec4 s0 = floor(b0)*2.0 + 1.0;
-        s0[0] = Math.floor(b0[0]) * 2.0 + 1.0;
-        s0[1] = Math.floor(b0[1]) * 2.0 + 1.0;
-        s0[2] = Math.floor(b0[2]) * 2.0 + 1.0;
-        s0[3] = Math.floor(b0[3]) * 2.0 + 1.0;
+        s0[0] = Math.floor(x[0]) * 2.0 + 1.0;
+        s0[1] = Math.floor(x[1]) * 2.0 + 1.0;
+        s0[2] = Math.floor(y[0]) * 2.0 + 1.0;
+        s0[3] = Math.floor(y[1]) * 2.0 + 1.0;
 
         // GLSL code:
         // vec4 s1 = floor(b1)*2.0 + 1.0;
-        s1[0] = Math.floor(b1[0]) * 2.0 + 1.0;
-        s1[1] = Math.floor(b1[1]) * 2.0 + 1.0;
-        s1[2] = Math.floor(b1[2]) * 2.0 + 1.0;
-        s1[3] = Math.floor(b1[3]) * 2.0 + 1.0;
+        s1[0] = Math.floor(x[2]) * 2.0 + 1.0;
+        s1[1] = Math.floor(x[3]) * 2.0 + 1.0;
+        s1[2] = Math.floor(y[2]) * 2.0 + 1.0;
+        s1[3] = Math.floor(y[3]) * 2.0 + 1.0;
 
         // GLSL code:
         // vec4 sh = -step(h, vec4(0.0));
@@ -278,49 +287,26 @@ var SimplexNoise = (function () {
         
         // GLSL code:
         // vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy ;
-        a0[0] = b0[0] + s0[0] * sh[0];
-        a0[1] = b0[2] + s0[2] * sh[0];
-        a0[2] = b0[1] + s0[1] * sh[1];
-        a0[3] = b0[3] + s0[3] * sh[1];
+        a0[0] = x[0] + s0[0] * sh[0];
+        a0[1] = y[0] + s0[2] * sh[0];
+        a0[2] = x[1] + s0[1] * sh[1];
+        a0[3] = y[1] + s0[3] * sh[1];
 
         // GLSL code:
         // vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww ;
-        a1[0] = b1[0] + s1[0] * sh[2];
-        a1[1] = b1[2] + s1[2] * sh[2];
-        a1[2] = b1[1] + s1[1] * sh[3];
-        a1[3] = b1[3] + s1[3] * sh[3];
+        a1[0] = x[2] + s1[0] * sh[2];
+        a1[1] = y[2] + s1[2] * sh[2];
+        a1[2] = x[3] + s1[1] * sh[3];
+        a1[3] = y[3] + s1[3] * sh[3];
 
-        // GLSL code:
-        // vec3 p0 = vec3(a0.xy,h.x);
-        p0[0] = a0[0];
-        p0[1] = a0[1];
-        p0[2] = h[0];
-
-        // GLSL code:
-        // vec3 p1 = vec3(a0.zw,h.y);
-        p1[0] = a0[2];
-        p1[1] = a0[3];
-        p1[2] = h[1];
-
-        // GLSL code:
-        // vec3 p2 = vec3(a1.xy,h.z);
-        p2[0] = a1[0];
-        p2[1] = a1[1];
-        p2[2] = h[2];
-
-        // GLSL code:
-        // vec3 p3 = vec3(a1.zw,h.w);
-        p3[0] = a1[2];
-        p3[1] = a1[3];
-        p3[2] = h[3];
 
         // Normalise gradients
         // GLSL code:
         // vec4 norm = taylorInvSqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2, p2), dot(p3,p3)));
-        norm[0] = vec3.dot(p0, p0);
-        norm[1] = vec3.dot(p1, p1);
-        norm[2] = vec3.dot(p2, p2);
-        norm[3] = vec3.dot(p3, p3);
+        norm[0] = a0[0] * a0[0] + a0[1] * a0[1] + h[0] * h[0];//vec3.dot(p0, p0);
+        norm[1] = a0[2] * a0[2] + a0[3] * a0[3] + h[1] * h[1];//vec3.dot(p1, p1);
+        norm[2] = a1[0] * a1[0] + a1[1] * a1[1] + h[2] * h[2];//vec3.dot(p2, p2);
+        norm[3] = a1[2] * a1[2] + a1[3] * a1[3] + h[3] * h[3];//vec3.dot(p3, p3);
 
         taylorInvSqrt_vec4(norm);
 
@@ -329,35 +315,67 @@ var SimplexNoise = (function () {
         // p1 *= norm.y;
         // p2 *= norm.z;
         // p3 *= norm.w;
-        p0 = vec3.scale(p0, p0, norm[0]);
-        p1 = vec3.scale(p1, p1, norm[1]);
-        p2 = vec3.scale(p2, p2, norm[2]);
-        p3 = vec3.scale(p3, p3, norm[3]);
+
+        // GLSL code:
+        // vec3 p0 = vec3(a0.xy,h.x);
+        //p0[0] = a0[0] * norm[0];
+        //p0[1] = a0[1] * norm[0];
+        //p0[2] =  h[0] * norm[0];
+        temp1[0] = a0[0] * norm[0] * x0[0] + a0[1] * norm[0] * x0[1] + h[0] * norm[0] * x0[2];
+
+        // GLSL code:
+        // vec3 p1 = vec3(a0.zw,h.y);
+        //p1[0] = a0[2] * norm[1];
+        //p1[1] = a0[3] * norm[1];
+        //p1[2] =  h[1] * norm[1];
+        temp1[1] = a0[2] * norm[1] * x1[0] + a0[3] * norm[1] * x1[1] + h[1] * norm[1] * x1[2];
+
+        // GLSL code:
+        // vec3 p2 = vec3(a1.xy,h.z);
+        //p2[0] = a1[0] * norm[2];
+        //p2[1] = a1[1] * norm[2];
+        //p2[2] =  h[2] * norm[2];*
+        temp1[2] = a1[0] * norm[2] * x2[0] + a1[1] * norm[2] * x2[1] + h[2] * norm[2] * x2[2];
+
+        // GLSL code:
+        // vec3 p3 = vec3(a1.zw,h.w);
+        //p3[0] = a1[2] * norm[3];
+        //p3[1] = a1[3] * norm[3];
+        //p3[2] =  h[3] * norm[3];
+        temp1[3] = a1[2] * norm[3] * x3[0] + a1[3] * norm[3] * x3[1] + h[3] * norm[3] * x3[2];
+
+        //p0 = vec3.scale(p0, p0, norm[0]);
+        //p1 = vec3.scale(p1, p1, norm[1]);
+        //p2 = vec3.scale(p2, p2, norm[2]);
+        //p3 = vec3.scale(p3, p3, norm[3]);
 
         // Mix final noise value
         // GLSL code:
         // vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
-        m[0] = Math.max(0.6 - vec3.dot(x0,x0), 0.0);
-        m[1] = Math.max(0.6 - vec3.dot(x1,x1), 0.0);
-        m[2] = Math.max(0.6 - vec3.dot(x2,x2), 0.0);
-        m[3] = Math.max(0.6 - vec3.dot(x3,x3), 0.0);
+        m[0] = Math.max(0.6 - vec3.dot(x0, x0), 0.0);
+        m[1] = Math.max(0.6 - vec3.dot(x1, x1), 0.0);
+        m[2] = Math.max(0.6 - vec3.dot(x2, x2), 0.0);
+        m[3] = Math.max(0.6 - vec3.dot(x3, x3), 0.0);
 
         // GLSL code:
         // m = m * m * m;
-        m[0] = m[0] * m[0] * m[0] * m[0];
+        /*m[0] = m[0] * m[0] * m[0] * m[0];
         m[1] = m[1] * m[1] * m[1] * m[1];
         m[2] = m[2] * m[2] * m[2] * m[2];
-        m[3] = m[3] * m[3] * m[3] * m[3];
+        m[3] = m[3] * m[3] * m[3] * m[3];*/
+
+        //var res = m[0] * m[0] * m[0] * m[0] * temp1[0] + m[1] * m[1] * m[1] * m[1] * temp1[1] + m[2] * m[2] * m[2] * m[2] * temp1[2] + m[3] * m[3] * m[3] * m[3] * temp1[3];
 
         // GLSL code:
         // return 42.0 * dot( m, vec4( dot(p0,x0), dot(p1,x1), 
         //                            dot(p2,x2), dot(p3,x3) ) );
-        temp1[0] = vec3.dot(p0, x0);
-        temp1[1] = vec3.dot(p1, x1);
-        temp1[2] = vec3.dot(p2, x2);
-        temp1[3] = vec3.dot(p3, x3);   
+        //temp1[0] = vec3.dot(p0, x0);
+        //temp1[1] = vec3.dot(p1, x1);
+        //temp1[2] = vec3.dot(p2, x2);
+        //temp1[3] = vec3.dot(p3, x3);
 
-        return 42.0 * vec4.dot(m, temp1);
+        //return 42.0 * vec4.dot(m, temp1);
+        return 42.0 * (m[0] * m[0] * m[0] * m[0] * temp1[0] + m[1] * m[1] * m[1] * m[1] * temp1[1] + m[2] * m[2] * m[2] * m[2] * temp1[2] + m[3] * m[3] * m[3] * m[3] * temp1[3]);
     };
 
     return {


### PR DESCRIPTION
Removing duplicated variable s0
Using perm array lookup
Removing the need for the b0 and b1 vectors
